### PR TITLE
CultureInfoExtensions: 3 Methods for temporarily overwrite Formats and/or Language

### DIFF
--- a/Quarks.Tests/CultureInfoExtensions/CultureOverrideTest.cs
+++ b/Quarks.Tests/CultureInfoExtensions/CultureOverrideTest.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Globalization;
+using System.Threading;
+using Machine.Specifications;
+using Quarks.CultureInfoExtensions;
+
+namespace Quarks.Tests.CultureInfoExtensions {
+
+    [Subject(typeof(CultureInfoExtension))]
+    class When_overriding_culture_enUS_with_deCH {
+
+        private void bla() {
+            CultureInfo deCH = new CultureInfo("de-CH", false);
+            try {
+                using (deCH.CultureOverride()) { //Temporarily switch language and format to Swiss-German.
+                    throw new ArgumentException();
+                }
+            } catch (Exception ex) {
+                //Write the German message to the console
+                Console.WriteLine(ex.Message);
+            }
+        }
+        Establish context = () => {
+            Thread myCurrentThread = Thread.CurrentThread;
+            myCurrentThread.CurrentCulture = enUS;
+            myCurrentThread.CurrentUICulture = enUS;
+        };
+
+        Because of = () => {
+            Thread myCurrentThread = Thread.CurrentThread;
+            FormatCultureBeforeOverride = myCurrentThread.CurrentCulture;
+            LanguageCultureBeforeOverride = myCurrentThread.CurrentUICulture;
+            TestDateBeforeOverride = TestDate.ToString("d");
+            TestNumberBeforeOverride = TestNumber.ToString("N");
+            TestMessageBeforeOverride = GetMessage();
+            using (deCH.CultureOverride()) {
+                FormatCultureDuringOverride = myCurrentThread.CurrentCulture;
+                LanguageCultureDuringOverride = myCurrentThread.CurrentUICulture;
+                TestDateDuringOverride = TestDate.ToString("d");
+                TestNumberDuringOverride = TestNumber.ToString("N");
+                TestMessageDuringOverride = GetMessage();
+            }
+            FormatCultureAfterOverride = myCurrentThread.CurrentCulture;
+            LanguageCultureAfterOverride = myCurrentThread.CurrentUICulture;
+            TestDateAfterOverride = TestDate.ToString("d");
+            TestNumberAfterOverride = TestNumber.ToString("N");
+            TestMessageAfterOverride = GetMessage();
+        };
+
+        //Values before the call
+
+        It should_be_format_enUS_before_the_call = () => {
+            FormatCultureBeforeOverride.ShouldBeTheSameAs(enUS);
+        };
+
+        It should_be_language_enUS_before_the_call = () => {
+            LanguageCultureBeforeOverride.ShouldBeTheSameAs(enUS);
+        };
+
+        It should_be_an_American_date_format_before_the_call = () => {
+            TestDateBeforeOverride.ShouldBeEqualIgnoringCase("12/31/2020");
+        };
+
+        It should_be_an_American_number_format_before_the_call = () => {
+            TestNumberBeforeOverride.ShouldBeEqualIgnoringCase("1,234.56");
+        };
+
+        It should_be_an_English_error_message_before_the_call = () => {
+            TestMessageBeforeOverride.ShouldBeLike("Value cannot be null.");
+        };
+
+        //Values during the call
+
+        It should_be_format_deCH_during_the_call = () => {
+            FormatCultureDuringOverride.ShouldBeTheSameAs(deCH);
+        };
+
+        It should_be_language_deCH_during_the_call = () => {
+            LanguageCultureDuringOverride.ShouldBeTheSameAs(deCH);
+        };
+
+        It should_be_a_Swiss_date_format_during_the_call = () => {
+            TestDateDuringOverride.ShouldBeEqualIgnoringCase("31.12.2020");
+        };
+
+        It should_be_a_Swiss_number_format_during_the_call = () => {
+            TestNumberDuringOverride.ShouldBeEqualIgnoringCase("1'234.56");
+        };
+
+        //Hint: Only works if the German language pack was installed
+        //Hint: Install or comment out test
+        It should_be_a_German_error_message_during_the_call = () => {
+            TestMessageDuringOverride.ShouldBeLike("Der Wert darf nicht NULL sein.");
+        };
+
+        //Values after the call
+
+        It should_be_format_enUS_after_the_call = () => {
+            FormatCultureAfterOverride.ShouldBeTheSameAs(enUS);
+        };
+
+        It should_be_language_enUS_after_the_call = () => {
+            LanguageCultureAfterOverride.ShouldBeTheSameAs(enUS);
+        };
+
+        It should_be_an_American_date_format_after_the_call = () => {
+            TestDateAfterOverride.ShouldBeEqualIgnoringCase("12/31/2020");
+        };
+
+        It should_be_an_American_number_format_after_the_call = () => {
+            TestNumberAfterOverride.ShouldBeEqualIgnoringCase("1,234.56");
+        };
+
+        It should_be_an_English_error_message_after_the_call = () => {
+            TestMessageAfterOverride.ShouldBeLike("Value cannot be null.");
+        };
+
+        //Private Functions
+
+        private static String GetMessage() {
+            //Hint: Got some inlining issues if exception was not thrown...
+            try {
+                throw new ArgumentNullException();
+            } catch (Exception ex) {
+                return ex.Message;
+            }
+        }
+
+        //Private Fields
+        private static CultureInfo FormatCultureBeforeOverride;
+        private static CultureInfo FormatCultureDuringOverride;
+        private static CultureInfo FormatCultureAfterOverride;
+        private static CultureInfo LanguageCultureBeforeOverride;
+        private static CultureInfo LanguageCultureDuringOverride;
+        private static CultureInfo LanguageCultureAfterOverride;
+        private static String TestDateBeforeOverride;
+        private static String TestDateDuringOverride;
+        private static String TestDateAfterOverride;
+        private static String TestNumberBeforeOverride;
+        private static String TestNumberDuringOverride;
+        private static String TestNumberAfterOverride;
+        private static String TestMessageBeforeOverride;
+        private static String TestMessageDuringOverride;
+        private static String TestMessageAfterOverride;
+        private static CultureInfo enUS = new CultureInfo("en-US", false);
+        private static CultureInfo deCH = new CultureInfo("de-CH", false);
+        private static DateTime TestDate = new DateTime(2020, 12, 31);
+        private static Decimal TestNumber = 1234.56M;
+
+    }
+
+}

--- a/Quarks.Tests/CultureInfoExtensions/FormatOverrideTest.cs
+++ b/Quarks.Tests/CultureInfoExtensions/FormatOverrideTest.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Globalization;
+using System.Threading;
+using Machine.Specifications;
+using Quarks.CultureInfoExtensions;
+
+namespace Quarks.Tests.CultureInfoExtensions {
+
+    [Subject(typeof(CultureInfoExtension))]
+    class When_overriding_format_enUS_with_deCH {
+
+        Establish context = () => {
+            Thread myCurrentThread = Thread.CurrentThread;
+            myCurrentThread.CurrentCulture = enUS;
+            myCurrentThread.CurrentUICulture = enUS;
+        };
+
+        Because of = () => {
+            Thread myCurrentThread = Thread.CurrentThread;
+            FormatCultureBeforeOverride = myCurrentThread.CurrentCulture;
+            LanguageCultureBeforeOverride = myCurrentThread.CurrentUICulture;
+            TestDateBeforeOverride = TestDate.ToString("d");
+            TestNumberBeforeOverride = TestNumber.ToString("N");
+            TestMessageBeforeOverride = GetMessage();
+            using (deCH.FormatOverride()) {
+                FormatCultureDuringOverride = myCurrentThread.CurrentCulture;
+                LanguageCultureDuringOverride = myCurrentThread.CurrentUICulture;
+                TestDateDuringOverride = TestDate.ToString("d");
+                TestNumberDuringOverride = TestNumber.ToString("N");
+                TestMessageDuringOverride = GetMessage();
+            }
+            FormatCultureAfterOverride = myCurrentThread.CurrentCulture;
+            LanguageCultureAfterOverride = myCurrentThread.CurrentUICulture;
+            TestDateAfterOverride = TestDate.ToString("d");
+            TestNumberAfterOverride = TestNumber.ToString("N");
+            TestMessageAfterOverride = GetMessage();
+        };
+
+        //Values before the call
+
+        It should_be_format_enUS_before_the_call = () => {
+            FormatCultureBeforeOverride.ShouldBeTheSameAs(enUS);
+        };
+
+        It should_be_language_enUS_before_the_call = () => {
+            LanguageCultureBeforeOverride.ShouldBeTheSameAs(enUS);
+        };
+
+        It should_be_an_American_date_format_before_the_call = () => {
+            TestDateBeforeOverride.ShouldBeEqualIgnoringCase("12/31/2020");
+        };
+
+        It should_be_an_American_number_format_before_the_call = () => {
+            TestNumberBeforeOverride.ShouldBeEqualIgnoringCase("1,234.56");
+        };
+
+        It should_be_an_English_error_message_before_the_call = () => {
+            TestMessageBeforeOverride.ShouldBeLike("Value cannot be null.");
+        };
+
+        //Values during the call
+
+        It should_be_format_deCH_during_the_call = () => {
+            FormatCultureDuringOverride.ShouldBeTheSameAs(deCH);
+        };
+
+        It should_be_language_enUS_during_the_call = () => {
+            LanguageCultureDuringOverride.ShouldBeTheSameAs(enUS);
+        };
+
+        It should_be_a_Swiss_date_format_during_the_call = () => {
+            TestDateDuringOverride.ShouldBeEqualIgnoringCase("31.12.2020");
+        };
+
+        It should_be_a_Swiss_number_format_during_the_call = () => {
+            TestNumberDuringOverride.ShouldBeEqualIgnoringCase("1'234.56");
+        };
+
+        It should_be_an_English_error_message_during_the_call = () => {
+            TestMessageDuringOverride.ShouldBeLike("Value cannot be null.");
+        };
+
+        //Values after the call
+
+        It should_be_format_enUS_after_the_call = () => {
+            FormatCultureAfterOverride.ShouldBeTheSameAs(enUS);
+        };
+
+        It should_be_language_enUS_after_the_call = () => {
+            LanguageCultureAfterOverride.ShouldBeTheSameAs(enUS);
+        };
+
+        It should_be_an_American_date_format_after_the_call = () => {
+            TestDateAfterOverride.ShouldBeEqualIgnoringCase("12/31/2020");
+        };
+
+        It should_be_an_American_number_format_after_the_call = () => {
+            TestNumberAfterOverride.ShouldBeEqualIgnoringCase("1,234.56");
+        };
+
+        It should_be_an_English_error_message_after_the_call = () => {
+            TestMessageAfterOverride.ShouldBeLike("Value cannot be null.");
+        };
+
+        //Private Functions
+
+        private static String GetMessage() {
+            //Hint: Got some inlining issues if exception was not thrown...
+            try {
+                throw new ArgumentNullException();
+            } catch (Exception ex) {
+                return ex.Message;
+            }
+        }
+
+        //Private Fields
+        private static CultureInfo FormatCultureBeforeOverride;
+        private static CultureInfo FormatCultureDuringOverride;
+        private static CultureInfo FormatCultureAfterOverride;
+        private static CultureInfo LanguageCultureBeforeOverride;
+        private static CultureInfo LanguageCultureDuringOverride;
+        private static CultureInfo LanguageCultureAfterOverride;
+        private static String TestDateBeforeOverride;
+        private static String TestDateDuringOverride;
+        private static String TestDateAfterOverride;
+        private static String TestNumberBeforeOverride;
+        private static String TestNumberDuringOverride;
+        private static String TestNumberAfterOverride;
+        private static String TestMessageBeforeOverride;
+        private static String TestMessageDuringOverride;
+        private static String TestMessageAfterOverride;
+        private static CultureInfo enUS = new CultureInfo("en-US", false);
+        private static CultureInfo deCH = new CultureInfo("de-CH", false);
+        private static DateTime TestDate = new DateTime(2020, 12, 31);
+        private static Decimal TestNumber = 1234.56M;
+
+    }
+
+}

--- a/Quarks.Tests/CultureInfoExtensions/LanguageOverrideTest.cs
+++ b/Quarks.Tests/CultureInfoExtensions/LanguageOverrideTest.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Globalization;
+using System.Threading;
+using Machine.Specifications;
+using Quarks.CultureInfoExtensions;
+
+namespace Quarks.Tests.CultureInfoExtensions {
+
+    [Subject(typeof(CultureInfoExtension))]
+    class When_overriding_language_enUS_with_deCH {
+
+        Establish context = () => {
+            Thread myCurrentThread = Thread.CurrentThread;
+            myCurrentThread.CurrentCulture = enUS;
+            myCurrentThread.CurrentUICulture = enUS;
+        };
+
+        Because of = () => {
+            Thread myCurrentThread = Thread.CurrentThread;
+            FormatCultureBeforeOverride = myCurrentThread.CurrentCulture;
+            LanguageCultureBeforeOverride = myCurrentThread.CurrentUICulture;
+            TestDateBeforeOverride = TestDate.ToString("d");
+            TestNumberBeforeOverride = TestNumber.ToString("N");
+            TestMessageBeforeOverride = GetMessage();
+            using (deCH.LanguageOverride()) {
+                FormatCultureDuringOverride = myCurrentThread.CurrentCulture;
+                LanguageCultureDuringOverride = myCurrentThread.CurrentUICulture;
+                TestDateDuringOverride = TestDate.ToString("d");
+                TestNumberDuringOverride = TestNumber.ToString("N");
+                TestMessageDuringOverride = GetMessage();
+            }
+            FormatCultureAfterOverride = myCurrentThread.CurrentCulture;
+            LanguageCultureAfterOverride = myCurrentThread.CurrentUICulture;
+            TestDateAfterOverride = TestDate.ToString("d");
+            TestNumberAfterOverride = TestNumber.ToString("N");
+            TestMessageAfterOverride = GetMessage();
+        };
+
+        //Values before the call
+
+        It should_be_format_enUS_before_the_call = () => {
+            FormatCultureBeforeOverride.ShouldBeTheSameAs(enUS);
+        };
+
+        It should_be_language_enUS_before_the_call = () => {
+            LanguageCultureBeforeOverride.ShouldBeTheSameAs(enUS);
+        };
+
+        It should_be_an_American_date_format_before_the_call = () => {
+            TestDateBeforeOverride.ShouldBeEqualIgnoringCase("12/31/2020");
+        };
+
+        It should_be_an_American_number_format_before_the_call = () => {
+            TestNumberBeforeOverride.ShouldBeEqualIgnoringCase("1,234.56");
+        };
+
+        It should_be_an_English_error_message_before_the_call = () => {
+            TestMessageBeforeOverride.ShouldBeLike("Value cannot be null.");
+        };
+
+        //Values during the call
+
+        It should_be_format_enUS_during_the_call = () => {
+            FormatCultureDuringOverride.ShouldBeTheSameAs(enUS);
+        };
+
+        It should_be_language_deCH_during_the_call = () => {
+            LanguageCultureDuringOverride.ShouldBeTheSameAs(deCH);
+        };
+
+        It should_be_an_American_date_format_during_the_call = () => {
+            TestDateDuringOverride.ShouldBeEqualIgnoringCase("12/31/2020");
+        };
+
+        It should_be_an_American_number_format_during_the_call = () => {
+            TestNumberDuringOverride.ShouldBeEqualIgnoringCase("1,234.56");
+        };
+
+        //Hint: Only works if the German language pack was installed
+        //Hint: Install or comment out test
+        It should_be_a_German_error_message_during_the_call = () => {
+            TestMessageDuringOverride.ShouldBeLike("Der Wert darf nicht NULL sein.");
+        };
+
+        //Values after the call
+
+        It should_be_format_enUS_after_the_call = () => {
+            FormatCultureAfterOverride.ShouldBeTheSameAs(enUS);
+        };
+
+        It should_be_language_enUS_after_the_call = () => {
+            LanguageCultureAfterOverride.ShouldBeTheSameAs(enUS);
+        };
+
+        It should_be_an_American_date_format_after_the_call = () => {
+            TestDateAfterOverride.ShouldBeEqualIgnoringCase("12/31/2020");
+        };
+
+        It should_be_an_American_number_format_after_the_call = () => {
+            TestNumberAfterOverride.ShouldBeEqualIgnoringCase("1,234.56");
+        };
+
+        It should_be_an_English_error_message_after_the_call = () => {
+            TestMessageAfterOverride.ShouldBeLike("Value cannot be null.");
+        };
+
+        //Private Functions
+
+        private static String GetMessage() {
+            //Hint: Got some inlining issues if exception was not thrown...
+            try {
+                throw new ArgumentNullException();
+            } catch (Exception ex) {
+                return ex.Message;
+            }
+        }
+
+        //Private Fields
+        private static CultureInfo FormatCultureBeforeOverride;
+        private static CultureInfo FormatCultureDuringOverride;
+        private static CultureInfo FormatCultureAfterOverride;
+        private static CultureInfo LanguageCultureBeforeOverride;
+        private static CultureInfo LanguageCultureDuringOverride;
+        private static CultureInfo LanguageCultureAfterOverride;
+        private static String TestDateBeforeOverride;
+        private static String TestDateDuringOverride;
+        private static String TestDateAfterOverride;
+        private static String TestNumberBeforeOverride;
+        private static String TestNumberDuringOverride;
+        private static String TestNumberAfterOverride;
+        private static String TestMessageBeforeOverride;
+        private static String TestMessageDuringOverride;
+        private static String TestMessageAfterOverride;
+        private static CultureInfo enUS = new CultureInfo("en-US", false);
+        private static CultureInfo deCH = new CultureInfo("de-CH", false);
+        private static DateTime TestDate = new DateTime(2020, 12, 31);
+        private static Decimal TestNumber = 1234.56M;
+
+    }
+
+}

--- a/Quarks.Tests/Quarks.Tests.csproj
+++ b/Quarks.Tests/Quarks.Tests.csproj
@@ -43,11 +43,13 @@
     <Reference Include="Machine.Fakes.Adapters.Moq">
       <HintPath>..\packages\Machine.Fakes.Moq.2.5.0\lib\net40\Machine.Fakes.Adapters.Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Machine.Specifications">
-      <HintPath>..\packages\Machine.Specifications.0.9.1\lib\net45\Machine.Specifications.dll</HintPath>
+    <Reference Include="Machine.Specifications, Version=0.9.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Machine.Specifications.0.9.3\lib\net45\Machine.Specifications.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Machine.Specifications.Clr4">
-      <HintPath>..\packages\Machine.Specifications.0.9.1\lib\net45\Machine.Specifications.Clr4.dll</HintPath>
+    <Reference Include="Machine.Specifications.Clr4, Version=0.9.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Machine.Specifications.0.9.3\lib\net45\Machine.Specifications.Clr4.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Machine.Specifications.Should">
       <HintPath>..\packages\Machine.Specifications.Should.0.7.2\lib\net45\Machine.Specifications.Should.dll</HintPath>
@@ -77,6 +79,9 @@
     <Compile Include="CapitalizeTests.cs">
       <DependentUpon>InflectorTests.cs</DependentUpon>
     </Compile>
+    <Compile Include="CultureInfoExtensions\FormatOverrideTest.cs" />
+    <Compile Include="CultureInfoExtensions\LanguageOverrideTest.cs" />
+    <Compile Include="CultureInfoExtensions\CultureOverrideTest.cs" />
     <Compile Include="DasherizeTests.cs">
       <DependentUpon>InflectorTests.cs</DependentUpon>
     </Compile>
@@ -167,7 +172,9 @@
       <DependentUpon>CustomTypeBinaryBlobTests.cs</DependentUpon>
     </None>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\System.Data.SQLite.Core.1.0.96.0\build\net451\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.96.0\build\net451\System.Data.SQLite.Core.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/Quarks.Tests/Quarks.Tests.csproj
+++ b/Quarks.Tests/Quarks.Tests.csproj
@@ -132,6 +132,7 @@
     <Compile Include="RetrierTests.cs" />
     <Compile Include="SentenceSplitAndJoinExtensionTests.cs" />
     <Compile Include="ObjectExtensions\ChangeTypeToTests.cs" />
+    <Compile Include="StringExtensions\ConvertAccentsTest.cs" />
     <Compile Include="TitleizeTests.cs">
       <DependentUpon>InflectorTests.cs</DependentUpon>
     </Compile>

--- a/Quarks.Tests/StringExtensions/ConvertAccentsTest.cs
+++ b/Quarks.Tests/StringExtensions/ConvertAccentsTest.cs
@@ -1,0 +1,462 @@
+﻿
+using System;
+using System.Globalization;
+using System.Threading;
+using Machine.Specifications;
+using Quarks.StringExtensions;
+
+namespace Quarks.Tests.StringExtensions {
+
+    [Subject(typeof(StringExtension))]
+    class When_calling_ConvertAccents {
+
+        //German umlauts
+
+        It should_convert_u_umlaut_to_ue = () => {
+            //German: "for"
+            String myTextBefore = "für";
+            String myTextAfter = "fuer";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_U_umlaut_to_Ue_in_normal_writing = () => {
+            //German: "exercise"
+            String myTextBefore = "Übung";
+            String myTextAfter = "Uebung";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_U_umlaut_to_UE_in_uppercase_writing = () => {
+            //German: "exercise"
+            String myTextBefore = "ÜBUNG";
+            String myTextAfter = "UEBUNG";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_a_umlaut_to_ae = () => {
+            //German: "offender"
+            String myTextBefore = "Täter";
+            String myTextAfter = "Taeter";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_A_umlaut_to_Ae_in_normal_writing = () => {
+            //German: "equator"
+            String myTextBefore = "Äquator";
+            String myTextAfter = "Aequator";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_A_umlaut_to_AE_in_uppercase_writing = () => {
+            //German: "equator"
+            String myTextBefore = "ÄQUATOR";
+            String myTextAfter = "AEQUATOR";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_o_umlaut_to_oe = () => {
+            //German: "furniture"
+            String myTextBefore = "Möbel";
+            String myTextAfter = "Moebel";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_O_umlaut_to_Oe_in_normal_writing = () => {
+            //German: "oil strainer"
+            String myTextBefore = "Ölfilter";
+            String myTextAfter = "Oelfilter";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_O_umlaut_to_OE_in_uppercase_writing = () => {
+            //German: "oil strainer"
+            String myTextBefore = "ÖLFILTER";
+            String myTextAfter = "OELFILTER";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_sharp_s_to_ss = () => {
+            //German: "foot"
+            String myTextBefore = "Fuß"; //lower-case sharp S
+            String myTextAfter = "Fuss";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        //Hint: It is common in German writing to use lowercase sharp-S even in all-uppercase-texts (although unicode does define an uppercase sharp-S)
+        It should_convert_uppercase_string_with_lowercase_sharp_s_to_SS = () => {
+            //German: "foot"
+            String myTextBefore = "FUß"; //lower-case sharp S
+            String myTextAfter = "FUSS";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        //Hint: Upper-case sharp-S is very uncommon in German, usually for upper- and lowercase sharp-S the lowercase letter is used!
+        It should_convert_uppercase_string_with_uppercase_sharp_S = () => {
+            //German: "foot"
+            String myTextBefore = "FUẞ"; //upper-case sharp S
+            String myTextAfter = "FUSS";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        //French grapheme
+
+        It should_convert_ae_grapheme_to_ae = () => {
+            //Danish: "apple"
+            String myTextBefore = "æble"; 
+            String myTextAfter = "aeble";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_AE_grapheme_to_AE_in_normal_writing = () => {
+            //Danish: "apple"
+            String myTextBefore = "Æble";
+            String myTextAfter = "AEble"; //An Æ remains "AE" and never becomes "Ae"
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_AE_grapheme_to_AE_in_uppercase_writing = () => {
+            //Danish: "apple"
+            String myTextBefore = "ÆBLE";
+            String myTextAfter = "AEBLE";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_oe_grapheme_to_oe = () => {
+            //French: "eye"
+            String myTextBefore = "œil"; 
+            String myTextAfter = "oeil";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_OE_grapheme_to_OE_in_normal_writing = () => {
+            //French: "eye"
+            String myTextBefore = "Œil";
+            String myTextAfter = "OEil"; //An Œ remains "OE" and never becomes "Oe"
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_OE_grapheme_to_OE_in_uppercase_writing = () => {
+            //French: "eye"
+            String myTextBefore = "ŒIL";
+            String myTextAfter = "OEIL";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        //Letter a
+
+        It should_convert_a_acute_to_a = () => {
+            //Icelandic: "effort"
+            String myTextBefore = "átak";
+            String myTextAfter = "atak";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_A_acute_to_A = () => {
+            //Icelandic: "effort"
+            String myTextBefore = "ÁTAK";
+            String myTextAfter = "ATAK";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_a_grave_to_a = () => {
+            //French: "here"
+            String myTextBefore = "voilà";
+            String myTextAfter = "voila";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_A_grave_to_A = () => {
+            //French: "here"
+            String myTextBefore = "VOILÀ";
+            String myTextAfter = "VOILA";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_a_circumflex_to_a = () => {
+            //French: "age"
+            String myTextBefore = "âge";
+            String myTextAfter = "age";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_A_circumflex_to_a = () => {
+            //French: "age"
+            String myTextBefore = "ÂGE";
+            String myTextAfter = "AGE";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        //Letter c
+
+        It should_convert_c_cedil_to_c = () => {
+            //French: "waiter" or "boy"
+            String myTextBefore = "garçon";
+            String myTextAfter = "garcon";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_C_cedil_to_C = () => {
+            //French: "waiter" or "boy"
+            String myTextBefore = "GARÇON";
+            String myTextAfter = "GARCON";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        //Letter e
+
+        It should_convert_e_acute_to_e = () => {
+            //French: "department"
+            String myTextBefore = "département";
+            String myTextAfter = "departement";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_E_acute_to_E = () => {
+            //French: "department"
+            String myTextBefore = "DÉPARTEMENT";
+            String myTextAfter = "DEPARTEMENT";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_e_grave_to_e = () => {
+            //French: "career"
+            String myTextBefore = "carrière";
+            String myTextAfter = "carriere";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_E_grave_to_E = () => {
+            //French: "career"
+            String myTextBefore = "CARRIÈRE";
+            String myTextAfter = "CARRIERE";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_e_circumflex_to_e = () => {
+            //French: "forest"
+            String myTextBefore = "forêt";
+            String myTextAfter = "foret";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_E_circumflex_to_E = () => {
+            //French: "forest"
+            String myTextBefore = "FORÊT";
+            String myTextAfter = "FORET";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_e_trema_to_e = () => {
+            //French: "Christmas"
+            String myTextBefore = "Noël";
+            String myTextAfter = "Noel";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_E_trema_to_e = () => {
+            //French: "Christmas"
+            String myTextBefore = "NOËL";
+            String myTextAfter = "NOEL";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        //Letter g
+
+        It should_convert_g_breve_to_g = () => {
+            //Turkish: "onion", "bulb"
+            String myTextBefore = "soğan";
+            String myTextAfter = "sogan";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_G_breve_to_G = () => {
+            //Turkish: "onion", "bulb"
+            String myTextBefore = "SOĞAN";
+            String myTextAfter = "SOGAN";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        //Letter i
+
+        It should_convert_i_acute_to_i = () => {
+            //Galician: "index"
+            String myTextBefore = "índice";
+            String myTextAfter = "indice";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_I_acute_to_I = () => {
+            //Galician: "index"
+            String myTextBefore = "ÍNDICE";
+            String myTextAfter = "INDICE";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_i_graphe_to_i = () => {
+            //Vietnamese: "river"
+            String myTextBefore = "rìu";
+            String myTextAfter = "riu";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_I_graphe_to_I = () => {
+            //Vietnamese: "river"
+            String myTextBefore = "RÌU";
+            String myTextAfter = "RIU";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_i_circumflex_to_i = () => {
+            //French: "island"
+            String myTextBefore = "île";
+            String myTextAfter = "ile";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_I_circumflex_to_I = () => {
+            //French: "island"
+            String myTextBefore = "ÎLE";
+            String myTextAfter = "ILE";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_i_trema_to_i = () => {
+            //French: "paranoid"
+            String myTextBefore = "paranoïde";
+            String myTextAfter = "paranoide";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_I_trema_to_I = () => {
+            //French: "paranoid"
+            String myTextBefore = "PARANOÏDE";
+            String myTextAfter = "PARANOIDE";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        //Letter n
+
+        It should_convert_n_tilde_to_n = () => {
+            //Spanish: "child"
+            String myTextBefore = "Niño";
+            String myTextAfter = "Nino";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_N_tilde_to_N = () => {
+            //Spanish: "child"
+            String myTextBefore = "NIÑO";
+            String myTextAfter = "NINO";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        //Letter o
+
+        It should_convert_o_acute_to_o = () => {
+            //Hungarian: "good"
+            String myTextBefore = "jó";
+            String myTextAfter = "jo";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_O_acute_to_O = () => {
+            //Hungarian: "good"
+            String myTextBefore = "jó";
+            String myTextAfter = "jo";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_o_circumflex_to_o = () => {
+            //French: "hospital"
+            String myTextBefore = "hôpital";
+            String myTextAfter = "hopital";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_O_circumflex_to_O = () => {
+            //French: "hospital"
+            String myTextBefore = "HÔPITAL";
+            String myTextAfter = "HOPITAL";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        //Letter s
+
+        It should_convert_s_cedil_to_s = () => {
+            //Turkish: "corpse"
+            String myTextBefore = "leş";
+            String myTextAfter = "les";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_S_cedil_to_S = () => {
+            //Turkish: "corpse"
+            String myTextBefore = "LEŞ";
+            String myTextAfter = "LES";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+
+        //Letter u
+
+        It should_convert_u_acute_to_u = () => {
+            //Spanish: "moist"
+            String myTextBefore = "húmedo";
+            String myTextAfter = "humedo";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_U_acute_to_U = () => {
+            //Spanish: "moist"
+            String myTextBefore = "HÚMEDO";
+            String myTextAfter = "HUMEDO";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_u_grave_to_u = () => {
+            //Breton: "name"
+            String myTextBefore = "anvioù";
+            String myTextAfter = "anviou";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_U_grave_to_U = () => {
+            //Breton: "name"
+            String myTextBefore = "ANVIOÙ";
+            String myTextAfter = "ANVIOU";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_u_circumflex_to_u = () => {
+            //French: "to cost"
+            String myTextBefore = "coûter";
+            String myTextAfter = "couter";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_U_circumflex_to_U = () => {
+            //French: "to cost"
+            String myTextBefore = "COÛTER";
+            String myTextAfter = "COUTER";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+        
+        //Letter y
+
+        It should_convert_y_acute_to_y = () => {
+            //Faroese: "Swamp"
+            String myTextBefore = "mýra";
+            String myTextAfter = "myra";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+        It should_convert_Y_acute_to_Y = () => {
+            //Faroese: "Swamp"
+            String myTextBefore = "MÝRA";
+            String myTextAfter = "MYRA";
+            myTextBefore.ConvertAccents().ShouldBeLike(myTextAfter);
+        };
+
+    }
+
+}

--- a/Quarks/CultureInfoExtensions/CultureOverride.cs
+++ b/Quarks/CultureInfoExtensions/CultureOverride.cs
@@ -1,0 +1,97 @@
+﻿//Courtesy of www.steffeninf.ch
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Quarks.CultureInfoExtensions {
+
+    internal static partial class CultureInfoExtension {
+
+        /// <summary>Temporarily changes the formats and language of the current thread to the ones of this culture info (internally Thread.CurrentThread.CurrentCulture and Thread.CurrentThread.CurrentUICulture are overwritten). 
+        /// If used in a using-block, the formats and language are automatically restored the moment the using-block is left. Dispose does not necessarily have to be called by the same thread,
+        /// the returned instance remembers the thread on which the culture info was adjusted and restores it again on the same thread. If dispose is called more than once, the second
+        /// and following calls are ignored.</summary>
+        /// <param name="culture">The culture info who's language to be temporarily used.</param>
+        /// <returns>An instance of IDisposable that can be wrapped by a "using"-block and that will automatically revert the CurrentCulture and CurrentUICulture of the calling thread to the values that has been set before this method was called.</returns>
+        /// <example>The Swiss-German language and formats are temporarily used to write a number as well as an error message to the console:
+        /// <code lang="C#">
+        /// CultureInfo deCH = new CultureInfo("de-CH", false);
+        /// using (deCH.CultureOverride()) {
+        ///     Console.Out.WriteLine("{0:N}", 1234.56); //Prints "1'234.56"
+        ///     try {
+        ///         Console.Out.WriteLine("{0:N}", 1234.56 / 0);
+        ///     } catch (Exception ex) {
+        ///         //Message is printed in German (if the according language pack is installed)
+        ///         Console.Out.WriteLine(ex.Message); 
+        ///     }
+        /// }
+        /// </code>
+        /// </example>
+        public static IDisposable CultureOverride(this CultureInfo culture) {
+            IDisposable myResult = new CurrentCultureOverride(culture, culture);
+            return myResult;
+        }
+
+
+        //*****************************************************************************************
+        // INNER CLASS: CultureOverrideImplementation
+        //*****************************************************************************************
+
+        /// <summary>Helper class used for temporarily override the current culture (date-, number-formats etc.) and/or UI culture (translations).</summary>
+        private class CurrentCultureOverride : IDisposable {
+
+            //Private Fields
+            private Thread _OriginalThread; 
+            private CultureInfo _OriginalFormatCulture;
+            private CultureInfo _OriginalLanguageCulture;
+
+            //Constructors
+
+            public CurrentCultureOverride(CultureInfo formatOverride, CultureInfo languageOverride) {
+                //Keep a reference to the thread (to allow "Dispose()" to be called from another thread)
+                Thread myThread = Thread.CurrentThread;
+                _OriginalThread = myThread;
+                //Change format culture
+                if (formatOverride != null) {
+                    _OriginalFormatCulture = myThread.CurrentCulture;
+                    myThread.CurrentCulture = formatOverride;
+                }
+                //Change language culture
+                if (languageOverride != null) {
+                    _OriginalLanguageCulture = myThread.CurrentUICulture;
+                    myThread.CurrentUICulture = languageOverride;
+                }
+            }
+
+            //Private Interface Implementation
+
+            void IDisposable.Dispose() {
+                //Load original thread
+                Thread myThread = _OriginalThread;
+                //Revert to original format
+                if (_OriginalFormatCulture != null) {
+                    try {
+                        myThread.CurrentCulture = _OriginalFormatCulture;
+                    } catch {
+                    }
+                    _OriginalFormatCulture = null;
+                }
+                //Revert to original language
+                if (_OriginalLanguageCulture != null) {
+                    try {
+                        myThread.CurrentUICulture = _OriginalLanguageCulture;
+                    } catch {
+                    }
+                    _OriginalLanguageCulture = null;
+                }
+            }
+
+        }
+
+    }
+
+}

--- a/Quarks/CultureInfoExtensions/FormatOverride.cs
+++ b/Quarks/CultureInfoExtensions/FormatOverride.cs
@@ -1,0 +1,77 @@
+﻿//Courtesy of www.steffeninf.ch
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Quarks.CultureInfoExtensions {
+
+    internal static partial class CultureInfoExtension {
+
+        /// <summary>Temporarily changes the formats of the current thread to the ones of this culture info (internally Thread.CurrentThread.CurrentCulture is overwritten). 
+        /// If used in a using-block, the formats are automatically restored the moment the using-block is left. Dispose does not necessarily have to be called by the same thread,
+        /// the returned instance remembers the thread on which the culture info was adjusted and restores it again on the same thread. If dispose is called more than once, the second
+        /// and following calls are ignored.</summary>
+        /// <param name="culture">The culture info who's formats and language to be temporarily used.</param>
+        /// <returns>An instance of IDisposable that can be wrapped by a "using"-block and that will automatically revert the CurrentCulture of the calling thread to the value that has been set before this method was called.</returns>
+        /// <example>The Swiss-German language format is temporarily used to write a number to the console:
+        /// <code lang="C#">
+        /// CultureInfo deCH = new CultureInfo("de-CH", false);
+        /// using (deCH.FormatOverride()) {
+        ///     Console.Out.WriteLine("{0:N}", 1234.56); //Prints "1'234.56"
+        /// }
+        /// </code>
+        /// </example>
+        public static IDisposable FormatOverride(this CultureInfo culture) {
+            IDisposable myResult = new CurrentFormatOverride(culture);
+            return myResult;
+        }
+
+
+        //*****************************************************************************************
+        // INNER CLASS: CultureOverrideImplementation
+        //*****************************************************************************************
+
+        /// <summary>Helper class used for temporarily override the current culture (date-, number-formats etc.) and/or UI culture (translations).</summary>
+        private class CurrentFormatOverride : IDisposable {
+
+            //Private Fields
+            private Thread _OriginalThread; 
+            private CultureInfo _OriginalFormatCulture;
+
+            //Constructors
+
+            public CurrentFormatOverride(CultureInfo formatOverride) {
+                //Keep a reference to the thread (to allow "Dispose()" to be called from another thread)
+                Thread myThread = Thread.CurrentThread;
+                _OriginalThread = myThread;
+                //Change format culture
+                if (formatOverride != null) {
+                    _OriginalFormatCulture = myThread.CurrentCulture;
+                    myThread.CurrentCulture = formatOverride;
+                }
+            }
+
+            //Private Interface Implementation
+
+            void IDisposable.Dispose() {
+                //Load original thread
+                Thread myThread = _OriginalThread;
+                //Revert to original format
+                if (_OriginalFormatCulture != null) {
+                    try {
+                        myThread.CurrentCulture = _OriginalFormatCulture;
+                    } catch {
+                    }
+                    _OriginalFormatCulture = null;
+                }
+            }
+
+        }
+
+    }
+
+}

--- a/Quarks/CultureInfoExtensions/LanguageOverride.cs
+++ b/Quarks/CultureInfoExtensions/LanguageOverride.cs
@@ -1,0 +1,82 @@
+﻿//Courtesy of www.steffeninf.ch
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Quarks.CultureInfoExtensions {
+
+    internal static partial class CultureInfoExtension {
+
+        /// <summary>Temporarily changes the language of the current thread to the one of this culture info (internally Thread.CurrentThread.CurrentUICulture is overwritten). 
+        /// If used in a using-block, the language is automatically restored the moment the using-block is left. Dispose does not necessarily have to be called by the same thread,
+        /// the returned instance remembers the thread on which the culture info was adjusted and restores it again on the same thread. If dispose is called more than once, the second
+        /// and following calls are ignored.</summary>
+        /// <param name="culture">The culture info who's language to be temporarily used.</param>
+        /// <returns>An instance of IDisposable that can be wrapped by a "using"-block and that will automatically revert the CurrentUICulture of the calling thread to the values that has been set before this method was called.</returns>
+        /// <example>The Swiss-German language is temporarily used to write an error message to the console:
+        /// <code lang="C#">
+        /// CultureInfo deCH = new CultureInfo("de-CH", false);
+        /// using (deCH.LanguageOverride()) {
+        ///     try {
+        ///         Console.Out.WriteLine("{0:N}", 1234.56 / 0);
+        ///     } catch (Exception ex) {
+        ///         //Message is printed in German (if the according language pack is installed)
+        ///         Console.Out.WriteLine(ex.Message); 
+        ///     }
+        /// }
+        /// </code>
+        /// </example>
+        public static IDisposable LanguageOverride(this CultureInfo culture) {
+            IDisposable myResult = new CurrentLanguageOverride(culture);
+            return myResult;
+        }
+
+
+        //*****************************************************************************************
+        // INNER CLASS: CultureOverrideImplementation
+        //*****************************************************************************************
+
+        /// <summary>Helper class used for temporarily override the current culture (date-, number-formats etc.) and/or UI culture (translations).</summary>
+        private class CurrentLanguageOverride : IDisposable {
+
+            //Private Fields
+            private Thread _OriginalThread; 
+            private CultureInfo _OriginalLanguageCulture;
+
+            //Constructors
+
+            public CurrentLanguageOverride(CultureInfo languageOverride) {
+                //Keep a reference to the thread (to allow "Dispose()" to be called from another thread)
+                Thread myThread = Thread.CurrentThread;
+                _OriginalThread = myThread;
+                //Change language culture
+                if (languageOverride != null) {
+                    _OriginalLanguageCulture = myThread.CurrentUICulture;
+                    myThread.CurrentUICulture = languageOverride;
+                }
+            }
+
+            //Private Interface Implementation
+
+            void IDisposable.Dispose() {
+                //Load original thread
+                Thread myThread = _OriginalThread;
+                //Revert to original language
+                if (_OriginalLanguageCulture != null) {
+                    try {
+                        myThread.CurrentUICulture = _OriginalLanguageCulture;
+                    } catch {
+                    }
+                    _OriginalLanguageCulture = null;
+                }
+            }
+
+        }
+
+    }
+
+}

--- a/Quarks/Quarks.csproj
+++ b/Quarks/Quarks.csproj
@@ -203,6 +203,7 @@
     <Compile Include="NHibernate\UserTypes\NullableTimeType.cs" />
     <Compile Include="NHibernate\UserTypes\UIntType.cs" />
     <Compile Include="NHibernate\UserTypes\UShortType.cs" />
+    <Compile Include="StringExtensions\ConvertAccents.cs" />
     <Compile Include="TypeExtensions\IsNullable.cs" />
     <None Include="AssertComparer.nuspec">
       <DependentUpon>AssertComparer.cs</DependentUpon>

--- a/Quarks/Quarks.csproj
+++ b/Quarks/Quarks.csproj
@@ -115,6 +115,9 @@
     <Compile Include="AppSettings.cs" />
     <Compile Include="AssemblyExtensions\GetIsDebugBuild.cs" />
     <Compile Include="AttributeHelper.cs" />
+    <Compile Include="CultureInfoExtensions\CultureOverride.cs" />
+    <Compile Include="CultureInfoExtensions\FormatOverride.cs" />
+    <Compile Include="CultureInfoExtensions\LanguageOverride.cs" />
     <Compile Include="DiagnosticsTextWriter.cs" />
     <Compile Include="DynamicDictionary.cs" />
     <Compile Include="EnumExtensions\GetAttributeOfType.cs" />

--- a/Quarks/StringExtensions/ConvertAccents.cs
+++ b/Quarks/StringExtensions/ConvertAccents.cs
@@ -1,0 +1,759 @@
+﻿//Courtesy of www.steffeninf.ch
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Quarks.StringExtensions {
+
+    internal static partial class StringExtension {
+
+        //Public Extension Methods
+
+        /// <summary>Converts accented characters into non-accented ones (e.g. "é" -&gt; "e", "ä" -&gt; "ae", "Ä" -&gt; "Ae" or "AE" (depends whether the neighboring 
+        /// characters are upper-case letters or not). A possible usage is to create login names or email addresses based on first- and last name. This
+        /// overload includes sign conversion (e.g. "©" -&gt; "(C)"). Unknown characters are not converted and returned the same way. To remove all unsupported
+        /// characters use in conjunction with extension method RemoveUnwantedChars(..).</summary>
+        /// <param name="text">The text where accented characters should be normalized.</param>
+        /// <returns>Returns a string without any accents, e.g. "élève" becomes "eleve".</returns>
+        /// <exception cref="System.NullReferenceException">Simulates instance method behavior, if a method is called on a NULL instance, a NullReferenceException is thrown.</exception>
+        public static String ConvertAccents(this String text) {
+            return ConvertAccents(text, false);
+        }
+
+        /// <exception cref="System.NullReferenceException">Simulates instance method behavior, if a method is called on a NULL instance, a NullReferenceException is thrown.</exception>
+        public static String ConvertAccents(this String text, Boolean noSignConversion) {
+            //Throw a NullReferenceException to simulate instance-method behavior
+            if (null == text) throw new NullReferenceException();
+            //Return unchanged if empty
+            if (String.IsNullOrEmpty(text)) return text;
+            //Change all accented chars
+            Char[] myCharArray = text.ToCharArray();
+            StringBuilder myResult = new StringBuilder(text.Length);
+            for (Int32 i = 0; i <= myCharArray.Length - 1; i++) {
+                Char myChar = myCharArray[i];
+                //Append normal chars directly
+                if (((myChar >= 'a') && (myChar <= 'z')) || ((myChar >= 'A') && (myChar <= 'Z')) || ((myChar >= '0') && (myChar <= '9'))) {
+                    myResult.Append(myChar);
+                    continue;
+                }
+                //Append other chars through method logic
+                AppendConvertedChar(myResult, myChar, i, myCharArray, !noSignConversion);
+            }
+            return myResult.ToString();
+        }
+
+        //Private Methods
+
+        private static void AppendConvertedChar(StringBuilder aResult, Char aChar, Int32 anIndex, Char[] aCharArray, Boolean convertSigns) {
+            switch (aChar) {
+                //Append most common German substitutes
+                case 'ä':
+                    aResult.Append("ae");
+                    return;
+                case 'ö':
+                    aResult.Append("oe");
+                    return;
+                case 'ü':
+                    aResult.Append("ue");
+                    return;
+                case 'ß':
+                    if ((IsAllUppercase(anIndex, aCharArray))) {
+                        aResult.Append("SS");
+                    } else {
+                        aResult.Append("ss");
+                    }
+                    return;
+                case 'Ä':
+                    if ((IsAllUppercase(anIndex, aCharArray))) {
+                        aResult.Append("AE");
+                    } else {
+                        aResult.Append("Ae");
+                    }
+                    return;
+                case 'Ö':
+                    if ((IsAllUppercase(anIndex, aCharArray))) {
+                        aResult.Append("OE");
+                    } else {
+                        aResult.Append("Oe");
+                    }
+                    return;
+                case 'Ü':
+                    if ((IsAllUppercase(anIndex, aCharArray))) {
+                        aResult.Append("UE");
+                    } else {
+                        aResult.Append("Ue");
+                    }
+                    return;
+                case 'ẞ': //upper-case sharp-S 
+                    aResult.Append("SS");
+                    return;
+                //Append one-letter substitutes
+                case 'À':
+                case 'Á':
+                case 'Â':
+                case 'Ã':
+                case 'Å':
+                case 'Ā':
+                case 'Ă':
+                case 'Ą':
+                case 'Ǎ':
+                case 'Ǻ':
+                case 'Ạ':
+                case 'Ả':
+                case 'Ấ':
+                case 'Ầ':
+                case 'Ẩ':
+                case 'Ẫ':
+                case 'Ậ':
+                case 'Ắ':
+                case 'Ằ':
+                case 'Ẳ':
+                case 'Ẵ':
+                case 'Ặ':
+                    aResult.Append('A');
+                    return;
+                case 'à':
+                case 'á':
+                case 'â':
+                case 'ã':
+                case 'å':
+                case 'ā':
+                case 'ă':
+                case 'ą':
+                case 'ǎ':
+                case 'ǻ':
+                case 'ạ':
+                case 'ả':
+                case 'ấ':
+                case 'ầ':
+                case 'ẩ':
+                case 'ẫ':
+                case 'ậ':
+                case 'ắ':
+                case 'ằ':
+                case 'ẳ':
+                case 'ẵ':
+                case 'ặ':
+                    aResult.Append('a');
+                    return;
+                case 'Ç':
+                case 'Ć':
+                case 'Ĉ':
+                case 'Ċ':
+                case 'Č':
+                    aResult.Append('C');
+                    return;
+                case 'ç':
+                case 'ć':
+                case 'ĉ':
+                case 'ċ':
+                case 'č':
+                    aResult.Append('c');
+                    return;
+                case 'Ð':
+                case 'Ď':
+                case 'Đ':
+                    aResult.Append('D');
+                    return;
+                case 'ď':
+                case 'đ':
+                    aResult.Append('d');
+                    return;
+                case 'È':
+                case 'É':
+                case 'Ê':
+                case 'Ë':
+                case 'Ē':
+                case 'Ĕ':
+                case 'Ė':
+                case 'Ę':
+                case 'Ě':
+                case 'Ẹ':
+                case 'Ẻ':
+                case 'Ẽ':
+                case 'Ế':
+                case 'Ề':
+                case 'Ể':
+                case 'Ễ':
+                case 'Ệ':
+                    aResult.Append('E');
+                    return;
+                case 'è':
+                case 'é':
+                case 'ê':
+                case 'ë':
+                case 'ē':
+                case 'ĕ':
+                case 'ė':
+                case 'ę':
+                case 'ě':
+                case 'ẹ':
+                case 'ẻ':
+                case 'ẽ':
+                case 'ế':
+                case 'ề':
+                case 'ể':
+                case 'ễ':
+                case 'ệ':
+                    aResult.Append('e');
+                    return;
+                case 'ƒ':
+                    aResult.Append('f');
+                    return;
+                case 'Ĝ':
+                case 'Ğ':
+                case 'Ġ':
+                case 'Ģ':
+                    aResult.Append('G');
+                    return;
+                case 'ĝ':
+                case 'ğ':
+                case 'ġ':
+                case 'ģ':
+                    aResult.Append('g');
+                    return;
+                case 'Ĥ':
+                case 'Ħ':
+                    aResult.Append('H');
+                    return;
+                case 'ĥ':
+                case 'ħ':
+                    aResult.Append('h');
+                    return;
+                case 'Ì':
+                case 'Í':
+                case 'Î':
+                case 'Ï':
+                case 'Ĩ':
+                case 'Ī':
+                case 'Ĭ':
+                case 'Į':
+                case 'İ':
+                case 'Ǐ':
+                case 'Ỉ':
+                case 'Ị':
+                    aResult.Append('I');
+                    return;
+                case 'ì':
+                case 'í':
+                case 'î':
+                case 'ï':
+                case 'ĩ':
+                case 'ī':
+                case 'ĭ':
+                case 'į':
+                case 'ı':
+                case 'ǐ':
+                case 'ỉ':
+                case 'ị':
+                    aResult.Append('i');
+                    return;
+                case 'Ĵ':
+                    aResult.Append('J');
+                    return;
+                case 'ĵ':
+                    aResult.Append('j');
+                    return;
+                case 'Ķ':
+                case 'ĸ':
+                    aResult.Append('K');
+                    return;
+                case 'ķ':
+                    aResult.Append('k');
+                    return;
+                case 'Ĺ':
+                case 'Ļ':
+                case 'Ŀ':
+                case 'Ł':
+                    aResult.Append('L');
+                    return;
+                case 'ĺ':
+                case 'ļ':
+                case 'ŀ':
+                case 'ł':
+                    aResult.Append('l');
+                    return;
+                case 'Ñ':
+                case 'Ń':
+                case 'Ņ':
+                case 'Ň':
+                    aResult.Append('N');
+                    return;
+                case 'ñ':
+                case 'ń':
+                case 'ņ':
+                case 'ň':
+                    aResult.Append('n');
+                    return;
+                case 'Ò':
+                case 'Ó':
+                case 'Ô':
+                case 'Õ':
+                case 'Ō':
+                case 'Ŏ':
+                case 'Ő':
+                case 'Ǒ':
+                case 'Ọ':
+                case 'Ỏ':
+                case 'Ố':
+                case 'Ồ':
+                case 'Ổ':
+                case 'Ỗ':
+                case 'Ộ':
+                case 'Ớ':
+                case 'Ờ':
+                case 'Ở':
+                case 'Ỡ':
+                case 'Ợ':
+                    aResult.Append('O');
+                    return;
+                case 'ò':
+                case 'ó':
+                case 'ô':
+                case 'õ':
+                case 'ō':
+                case 'ŏ':
+                case 'ő':
+                case 'ǒ':
+                case 'ọ':
+                case 'ỏ':
+                case 'ố':
+                case 'ồ':
+                case 'ổ':
+                case 'ỗ':
+                case 'ộ':
+                case 'ớ':
+                case 'ờ':
+                case 'ở':
+                case 'ỡ':
+                case 'ợ':
+                    aResult.Append('o');
+                    return;
+                case 'Þ': //Capital thorn
+                    if ((IsAllUppercase(anIndex, aCharArray))) {
+                        aResult.Append("TH");
+                    } else {
+                        aResult.Append("Th");
+                    }
+                    return;
+                case 'þ': //Lowercase thorn
+                    aResult.Append("th"); //thorn
+                    return;
+                case 'Ŕ':
+                case 'Ŗ':
+                case 'Ř':
+                    aResult.Append('R');
+                    return;
+                case 'ŕ':
+                case 'ŗ':
+                case 'ř':
+                    aResult.Append('r');
+                    return;
+                case 'Ś':
+                case 'Ŝ':
+                case 'Ş':
+                case 'Š':
+                    aResult.Append('S');
+                    return;
+                case 'ś':
+                case 'ŝ':
+                case 'ş':
+                case 'š':
+                    aResult.Append('s');
+                    return;
+                case 'Ţ':
+                case 'Ť':
+                case 'Ŧ':
+                    aResult.Append('T');
+                    return;
+                case 'ţ':
+                case 'ť':
+                case 'ŧ':
+                    aResult.Append('t');
+                    return;
+                case 'Ù':
+                case 'Ú':
+                case 'Û':
+                case 'Ů':
+                case 'Ű':
+                case 'Ų':
+                case 'Ǔ':
+                case 'Ǖ':
+                case 'Ǘ':
+                case 'Ǚ':
+                case 'Ǜ':
+                case 'Ụ':
+                case 'Ủ':
+                case 'Ứ':
+                case 'Ừ':
+                case 'Ử':
+                case 'Ữ':
+                case 'Ự':
+                    aResult.Append('U');
+                    return;
+                case 'ù':
+                case 'ú':
+                case 'û':
+                case 'ů':
+                case 'ű':
+                case 'ų':
+                case 'ǔ':
+                case 'ǖ':
+                case 'ǘ':
+                case 'ǚ':
+                case 'ǜ':
+                case 'ụ':
+                case 'ủ':
+                case 'ứ':
+                case 'ừ':
+                case 'ử':
+                case 'ữ':
+                case 'ự':
+                    aResult.Append('u');
+                    return;
+                case 'Ŵ':
+                case 'Ẁ':
+                case 'Ẃ':
+                case 'Ẅ':
+                    aResult.Append('W');
+                    return;
+                case 'ŵ':
+                case 'ẁ':
+                case 'ẃ':
+                case 'ẅ':
+                    aResult.Append('w');
+                    return;
+                case 'Ý':
+                case 'Ŷ':
+                case 'Ÿ':
+                case 'Ỳ':
+                case 'Ỵ':
+                case 'Ỷ':
+                case 'Ỹ':
+                    aResult.Append('Y');
+                    return;
+                case 'ý':
+                case 'ÿ':
+                case 'ŷ':
+                case 'ỳ':
+                case 'ỵ':
+                case 'ỷ':
+                case 'ỹ':
+                    aResult.Append('y');
+                    return;
+                case 'Ź':
+                case 'Ż':
+                case 'Ž':
+                    aResult.Append('Z');
+                    return;
+                case 'ź':
+                case 'ż':
+                case 'ž':
+                    aResult.Append('z');
+                    return;
+                case 'æ':
+                case 'ǽ':
+                    aResult.Append("ae");
+                    return;
+                case 'Æ':
+                case 'Ǽ':
+                    aResult.Append("AE");
+                    return;
+                case 'Ø':
+                case 'Ǿ':
+                    if ((IsAllUppercase(anIndex, aCharArray))) {
+                        aResult.Append("OE");
+                    } else {
+                        aResult.Append("Oe");
+                    }
+                    return;
+                case 'ø':
+                case 'ǿ':
+                case 'œ':
+                    aResult.Append("oe");
+                    return;
+                case 'Œ':
+                    aResult.Append("OE"); //Always both remain uppercase
+                    return;
+                case 'Ľ':
+                    aResult.Append("L'");
+                    return;
+                case 'ľ':
+                    aResult.Append("l'");
+                    return;
+                case 'ŉ':
+                    aResult.Append("'n");
+                    return;
+                case 'Ơ':
+                    aResult.Append("O'");
+                    return;
+                case 'ơ':
+                    aResult.Append("o'");
+                    return;
+                case 'Ư':
+                    aResult.Append("U'");
+                    return;
+                case 'ư':
+                    aResult.Append("u'");
+                    return;
+                case 'Ĳ': //Always both remain uppercase
+                    aResult.Append("IJ");
+                    return;
+                case 'ĳ':
+                    aResult.Append("ij");
+                    return;
+                case '⁰':
+                    aResult.Append('0');
+                    return;
+                case '¹':
+                    aResult.Append('1');
+                    return;
+                case '²':
+                    aResult.Append('2');
+                    return;
+                case '³':
+                    aResult.Append('3');
+                    return;
+                case '⁴':
+                    aResult.Append('4');
+                    return;
+                case '⁵':
+                    aResult.Append('5');
+                    return;
+                case '⁶':
+                    aResult.Append('6');
+                    return;
+                case '⁷':
+                    aResult.Append('7');
+                    return;
+                case '⁸':
+                    aResult.Append('8');
+                    return;
+                case '⁹':
+                    aResult.Append('9');
+                    return;
+                case '₀':
+                    aResult.Append('0');
+                    return;
+                case '₁':
+                    aResult.Append('1');
+                    return;
+                case '₂':
+                    aResult.Append('2');
+                    return;
+                case '₃':
+                    aResult.Append('3');
+                    return;
+                case '₄':
+                    aResult.Append('4');
+                    return;
+                case '₅':
+                    aResult.Append('5');
+                    return;
+                case '₆':
+                    aResult.Append('6');
+                    return;
+                case '₇':
+                    aResult.Append('7');
+                    return;
+                case '₈':
+                    aResult.Append('8');
+                    return;
+                case '₉':
+                    aResult.Append('9');
+                    return;
+            }
+            //If signs should also be converted
+            if (convertSigns) {
+                switch (aChar) {
+                    case ' ':
+                        aResult.Append(' ');
+                        return;
+                    case ' ':
+                        aResult.Append(' ');
+                        return;
+                    case ' ':
+                        aResult.Append(' ');
+                        return;
+                    case ' ':
+                        aResult.Append(' ');
+                        return;
+                    case '¢':
+                        aResult.Append("c");
+                        return;
+                    case '©':
+                        aResult.Append("(C)");
+                        return;
+                    case '®':
+                        aResult.Append("(R)");
+                        return;
+                    case '™':
+                        aResult.Append("TM");
+                        return;
+                    case 'ª':
+                        aResult.Append('a');
+                        return;
+                    case 'º':
+                        aResult.Append('o');
+                        return;
+                    case '·':
+                        aResult.Append('*');
+                        return;
+                    case '«':
+                        aResult.Append('\"');
+                        return;
+                    case '»':
+                        aResult.Append('\"');
+                        return;
+                    case '¯':
+                        aResult.Append('-');
+                        return;
+                    case '±':
+                        aResult.Append("+/-");
+                        return;
+                    case '´':
+                        aResult.Append('\'');
+                        return;
+                    case '‘':
+                        aResult.Append('\'');
+                        return;
+                    case '’':
+                        aResult.Append('\'');
+                        return;
+                    case '‚':
+                        aResult.Append('\'');
+                        return;
+                    case '“':
+                        aResult.Append('\"');
+                        return;
+                    case '”':
+                        aResult.Append('\"');
+                        return;
+                    case '„':
+                        aResult.Append('\"');
+                        return;
+                    case '¼':
+                        aResult.Append("1/4");
+                        return;
+                    case '½':
+                        aResult.Append("1/2");
+                        return;
+                    case '¾':
+                        aResult.Append("3/4");
+                        return;
+                    case '×':
+                        aResult.Append('*');
+                        return;
+                    case '÷':
+                        aResult.Append('/');
+                        return;
+                    case '−':
+                        aResult.Append('-');
+                        return;
+                    case '–':
+                        aResult.Append('-');
+                        return;
+                    case '—':
+                        aResult.Append('-');
+                        return;
+                    case '∗':
+                        aResult.Append('*');
+                        return;
+                    case '≠':
+                        aResult.Append("<>");
+                        return;
+                    case '≤':
+                        aResult.Append("<=");
+                        return;
+                    case '≥':
+                        aResult.Append(">=");
+                        return;
+                    case '⋅':
+                        aResult.Append('*');
+                        return;
+                    case '〈':
+                        aResult.Append(" <");
+                        return;
+                    case '〉':
+                        aResult.Append("> ");
+                        return;
+                    case '←':
+                        aResult.Append("<-");
+                        return;
+                    case '→':
+                        aResult.Append("->");
+                        return;
+                    case '↔':
+                        aResult.Append("<->");
+                        return;
+                    case '⇐':
+                        aResult.Append("<=");
+                        return;
+                    case '⇒':
+                        aResult.Append("=>");
+                        return;
+                    case '⇔':
+                        aResult.Append("<=>");
+                        return;
+                    case '•':
+                        aResult.Append('-');
+                        return;
+                    case '′':
+                        aResult.Append('\'');
+                        return;
+                    case '″':
+                        aResult.Append('\"');
+                        return;
+                    case '‾':
+                        aResult.Append('-');
+                        return;
+                    case '⁄':
+                        aResult.Append('/');
+                        return;
+                    case '℘':
+                        aResult.Append('p');
+                        return;
+                    case 'ℑ':
+                        aResult.Append('J');
+                        return;
+                    case 'ℜ':
+                        aResult.Append('R');
+                        return;
+                    case '…':
+                        aResult.Append("...");
+                        return;
+                    case '‹':
+                        aResult.Append('<');
+                        return;
+                    case '›':
+                        aResult.Append('>');
+                        return;
+                }
+            }
+            //Otherwise simply add the Char
+            aResult.Append(aChar);
+        }
+
+        private static Boolean IsAllUppercase(Int32 anIndex, Char[] aCharArray) {
+            //Simple implementation that respects only the next/previous Char
+            Char? myNeighbor = GetChar(anIndex + 1, aCharArray);
+            if ((myNeighbor == null) || (myNeighbor == 'ß') || ((!Char.IsUpper(myNeighbor.Value)) && (!Char.IsLower(myNeighbor.Value)))) {
+                myNeighbor = GetChar(anIndex - 1, aCharArray);
+            }
+            if ((myNeighbor == null) || (!Char.IsUpper(myNeighbor.Value))) {
+                return false;
+            }
+            return true;
+        }
+
+        private static Char? GetChar(Int32 index, Char[] charArray) {
+            if (index < 0) return null;
+            if (index >= charArray.Length) return null;
+            return charArray[index];
+        }
+
+    }
+
+}

--- a/Quarks/packages.config
+++ b/Quarks/packages.config
@@ -7,7 +7,7 @@
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net451" />
   <package id="Machine.Fakes" version="2.5.0" targetFramework="net451" />
   <package id="Machine.Fakes.Moq" version="2.5.0" targetFramework="net451" />
-  <package id="Machine.Specifications" version="0.9.1" targetFramework="net451" />
+  <package id="Machine.Specifications" version="0.9.3" targetFramework="net451" />
   <package id="Machine.Specifications.Should" version="0.7.2" targetFramework="net451" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net451" />


### PR DESCRIPTION
Provided 3 extension methods to instances of CultureInfo to temporarily overwrite the currently active language, to overwrite the currently active number- and date-formats and one for temporarily overwrite both.

A IDisposable is returned that can be used in a "using"-block and that automatically restores the previously set values when the "using"-block is left.

PS: I am new to github and MSpec-tests, so please forgive if I submit empty pull-requests or write a test in a crooked way...
